### PR TITLE
Check if key is undefined before attempting to access property.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -99,6 +99,12 @@ DynamoUtil.normalizeItem = function($item) {
 
 	var normal = {}
 	for (var key in $item) {
+
+                // If a key value is not set we should return empty object.
+		if($item[key] === undefined)
+			return normal;
+
+
 		if ($item.hasOwnProperty(key)) {
 			if ($item[key].hasOwnProperty('S'))
 				normal[key] = $item[key]['S']


### PR DESCRIPTION
Certain circumstances would cause an item to be passed in with an undefined key, which would then create an exception. This will prevent the exception.
