### PR TITLE
Removing the sql parser

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -29,7 +29,7 @@
 	var Dynamo = require('aws-sdk/clients/dynamodb')
 	var AWS = { DynamoDB: Dynamo };
 
-	var sqlparser = require('./sqlparser.js');
+	/* var sqlparser = require('./sqlparser.js');
 	sqlparser.parser.yy.extend = function (a,b){
 		if(typeof a == 'undefined') a = {};
 		for(var key in b) {
@@ -38,7 +38,7 @@
 			}
 		}
 		return a;
-	}
+	} */
 
 
 	var filterOperators = {
@@ -303,13 +303,13 @@
 		return new Request( this.client, { events: this.events, describeTables: this.describeTables, return_explain: re, } ).table($tableName)
 	}
 
-
+/*
 	DynamoDB.prototype.query = function() {
 		var re = this.return_explain; this.return_explain = false;
 		var r = new Request( this.client, { events: this.events, describeTables: this.describeTables, return_explain: re, } )
 		return r.sql(arguments[0],arguments[1]);
 	}
-
+*/
 	DynamoDB.prototype.batch = function( ) {
 		var re = this.return_explain; this.return_explain = false;
 		return new Batch( this.client, { events: this.events, describeTables: this.describeTables, return_explain: re, } )
@@ -1221,7 +1221,8 @@
 		})
 	}
 
-	Request.prototype.sql = function( sql, callback ) {
+	
+	/* Request.prototype.sql = function( sql, callback ) {
 		var $this = this;
 
 		var sqp;
@@ -1592,7 +1593,7 @@
 				return callback({ errorCode: 'UNSUPPORTED_QUERY_TYPE' })
 				break;
 		}
-	}
+	}*/
 
 	Request.prototype.resume = function( from ) {
 		this.ExclusiveStartKey = from

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -25,9 +25,9 @@
 
 	var Promise = require('promise')
 	var util = require('@awspilot/dynamodb-util')
-	var AWS = require('aws-sdk/global')
+
 	var Dynamo = require('aws-sdk/clients/dynamodb')
-	AWS.DynamoDB = Dynamo;
+	var AWS = { DynamoDB: Dynamo };
 
 	var sqlparser = require('./sqlparser.js');
 	sqlparser.parser.yy.extend = function (a,b){

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -25,7 +25,10 @@
 
 	var Promise = require('promise')
 	var util = require('@awspilot/dynamodb-util')
-	var AWS = require('aws-sdk')
+	var AWS = require('aws-sdk/global')
+	var Dynamo = require('aws-sdk/clients/dynamodb')
+	AWS.DynamoDB = Dynamo;
+
 	var sqlparser = require('./sqlparser.js');
 	sqlparser.parser.yy.extend = function (a,b){
 		if(typeof a == 'undefined') a = {};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"promise",
 		"nosql"
 	],
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"homepage": "https://awspilot.github.io/dynamodb-oop/",
 	"bugs": "https://github.com/awspilot/dynamodb-oop/issues",
 	"repository": {
@@ -23,8 +23,8 @@
 	"main": "./lib/dynamodb",
 	"license": "MIT",
 	"dependencies": {
-		"aws-sdk": "^2.432.0",
 		"@awspilot/dynamodb-util": "1.0.12",
+		"aws-sdk": "^2.432.0",
 		"promise": "8.0.2"
 	},
 	"devDependencies": {

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -13,7 +13,9 @@ dynaliteServer.listen(8000, function(err) {
 })
 */
 
-var AWS = require('aws-sdk')
+var AWS = require('aws-sdk/global')
+var Dynamo = require('aws-sdk/clients/dynamodb')
+AWS.DynamoDB = Dynamo;
 
 const DynamodbFactory = require('../../lib/dynamodb')
 


### PR DESCRIPTION
The sql parser adds an additional 30+kb to client builds, and it's a feature that's not effectively documented. I removed it in this branch and did get a large decrease in build size due to the sql parser generated code being left out.